### PR TITLE
Support build by stack.

### DIFF
--- a/uom-plugin-examples/stack.yaml
+++ b/uom-plugin-examples/stack.yaml
@@ -1,0 +1,9 @@
+resolver: lts-3.11
+packages:
+- '.'
+- location: '../uom-plugin/'
+  extra-deps: true
+extra-deps:
+- units-parser-0.1.0.0
+- uom-plugin-0.1.1.0
+flags: {}

--- a/uom-plugin/stack.yaml
+++ b/uom-plugin/stack.yaml
@@ -1,0 +1,5 @@
+resolver: lts-3.11
+packages:
+- '.'
+extra-deps:
+- units-parser-0.1.0.0


### PR DESCRIPTION
Long time no see, but I've found time to play with my most favorite unit-of-measure plugin again, and first of all, I had to migrate to Haskellers' new-generation build tool `stack` .

I can share the `stack.yaml` files I have written (although those are quite trivial,) but I have no idea if it's good to include them with the git repository. What do you think? 
