### PR TITLE
Read for quantities

### DIFF
--- a/uom-plugin/src/Data/UnitsOfMeasure.hs
+++ b/uom-plugin/src/Data/UnitsOfMeasure.hs
@@ -65,6 +65,7 @@ module Data.UnitsOfMeasure
 
 import Data.UnitsOfMeasure.Convert
 import Data.UnitsOfMeasure.Internal
+import Data.UnitsOfMeasure.Read ()
 import Data.UnitsOfMeasure.Show ()
 import Data.UnitsOfMeasure.Singleton
 import Data.UnitsOfMeasure.TH

--- a/uom-plugin/src/Data/UnitsOfMeasure/Internal.hs
+++ b/uom-plugin/src/Data/UnitsOfMeasure/Internal.hs
@@ -198,6 +198,7 @@ sqrt' (MkQuantity x) = MkQuantity (sqrt x)
 -- units, for example 'One' is represented as @[] ':/' []@ and
 -- @'Base' "m" '/:' 'Base' "s" ^: 2@ is represented as @["m"] ':/' ["s","s"]@.
 data UnitSyntax s = [s] :/ [s]
+  deriving (Eq, Show)
 
 -- | Pack up a syntactic representation of a unit as a unit.  For example:
 --

--- a/uom-plugin/src/Data/UnitsOfMeasure/Read.hs
+++ b/uom-plugin/src/Data/UnitsOfMeasure/Read.hs
@@ -15,7 +15,7 @@ module Data.UnitsOfMeasure.Read
    , readUnit
    , readWithUnit
    , Some(..)
-   , SomeQuantity(..)
+   , QuantityWithUnit(..)
    ) where
 
 import Control.Monad (join)
@@ -28,14 +28,14 @@ import Text.Parse.Units (parseUnit, universalSymbolTable, UnitExp(..))
 import Data.UnitsOfMeasure.Internal
 import Data.UnitsOfMeasure.Singleton
 
-data SomeQuantity a where
-  SomeQuantity :: Quantity a (Pack u) -> SUnit u -> SomeQuantity a
+-- | Represents a quantity whose units have a syntactic representation
+-- that is known statically and at runtime.
+data QuantityWithUnit a u where
+  QuantityWithUnit :: Quantity a (Pack u) -> SUnit u -> QuantityWithUnit a u
 
+-- | An existential wrapper type: @'Some' p@ is essentially @exists x . p x@.
 data Some p where
   Some :: p x -> Some p
-
-instance Show (Some SUnit) where
-  show (Some u) = show (forgetSUnit u)
 
 instance (KnownUnit (Unpack u), u ~ Pack (Unpack u), Read a) => Read (Quantity a u) where
   readsPrec i (' ':s) = readsPrec i s
@@ -45,18 +45,19 @@ instance (KnownUnit (Unpack u), u ~ Pack (Unpack u), Read a) => Read (Quantity a
   readsPrec _ _ = []
 
 -- | Parse a quantity and check that it has the expected units.
-readWithUnit :: forall proxy a u . (Read a, KnownUnit u) => proxy u -> String -> Either String (Quantity a (Pack u))
+readWithUnit :: forall proxy a u . (Read a, KnownUnit u)
+             => proxy u -> String -> Either String (Quantity a (Pack u))
 readWithUnit _ s = do
-  SomeQuantity (q :: Quantity a _) v <- readQuantity s
+  Some (QuantityWithUnit (q :: Quantity a _) v) <- readQuantity s
   case testEquivalentSUnit (unitSing :: SUnit u) v of
     Just Refl -> Right q
     Nothing   -> Left ("wrong units: got " ++ show (forgetSUnit v))
 
 -- | Parse a quantity along with its units.
-readQuantity :: Read a => String -> Either String (SomeQuantity a)
+readQuantity :: Read a => String -> Either String (Some (QuantityWithUnit a))
 readQuantity s = case reads s of
                    [(n, s')] -> do Some u <- readUnit s'
-                                   return $ SomeQuantity (MkQuantity n) u
+                                   return $ Some (QuantityWithUnit (MkQuantity n) u)
                    _         -> Left "reads: no parse"
 
 -- | Parse a unit.

--- a/uom-plugin/src/Data/UnitsOfMeasure/Read.hs
+++ b/uom-plugin/src/Data/UnitsOfMeasure/Read.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+
+module Data.UnitsOfMeasure.Read
+   ( readQuantity
+   , readUnit
+   , Some(..)
+   ) where
+
+import Control.Monad (join)
+import Data.List (genericReplicate)
+import GHC.TypeLits
+import Text.Parse.Units (parseUnit, universalSymbolTable, UnitExp(..))
+
+import Data.UnitsOfMeasure.Internal
+import Data.UnitsOfMeasure.Singleton
+
+data SomeQuantity a where
+  SomeQuantity :: Quantity a (Pack u) -> SUnit u -> SomeQuantity a
+
+data Some p where
+  Some :: p x -> Some p
+
+instance Show (Some SUnit) where
+  show (Some u) = show (forgetSUnit u)
+
+readQuantity :: Read a => String -> Either String (SomeQuantity a)
+readQuantity s = case reads s of
+                   [(n, s')] -> do Some u <- readUnit s'
+                                   return $ SomeQuantity (MkQuantity n) u
+                   _         -> Left "readQuantity borked"
+
+readUnit :: String -> Either String (Some SUnit)
+readUnit s = expToSomeUnit <$> parseUnit universalSymbolTable s
+
+expToSomeUnit :: UnitExp () String -> Some SUnit
+expToSomeUnit = unitSyntaxToSomeUnit . expToUnitSyntax
+
+unitSyntaxToSomeUnit :: UnitSyntax String -> Some SUnit
+unitSyntaxToSomeUnit (xs :/ ys) = case (someListVal xs, someListVal ys) of
+  (Some xs', Some ys') -> Some (SUnit xs' ys')
+
+someListVal :: [String] -> Some SList
+someListVal [] = Some SNil
+someListVal (x:xs) = case (someSymbolVal x, someListVal xs) of
+                       (SomeSymbol x', Some xs') -> Some (SCons x' xs')
+
+expToUnitSyntax :: UnitExp () String -> UnitSyntax String
+expToUnitSyntax Unity = [] :/ []
+expToUnitSyntax (Unit _ s) = [s] :/ []
+expToUnitSyntax (u `Mult` v) = (u_xs ++ v_xs) :/ (u_ys ++ v_ys)
+  where
+    u_xs :/ u_ys = expToUnitSyntax u
+    v_xs :/ v_ys = expToUnitSyntax v
+expToUnitSyntax (u `Div` v) = (u_xs ++ v_ys) :/ (u_ys ++ v_xs)
+  where
+    u_xs :/ u_ys = expToUnitSyntax u
+    v_xs :/ v_ys = expToUnitSyntax v
+expToUnitSyntax (u `Pow` n)
+    | n >= 0    = join (genericReplicate n u_xs) :/ join (genericReplicate n u_ys)
+    | otherwise = join (genericReplicate (negate n) u_ys) :/ join (genericReplicate (negate n) u_xs)
+  where
+    u_xs :/ u_ys = expToUnitSyntax u

--- a/uom-plugin/src/Data/UnitsOfMeasure/Read.hs
+++ b/uom-plugin/src/Data/UnitsOfMeasure/Read.hs
@@ -22,7 +22,7 @@ import Control.Monad (join)
 import GHC.TypeLits
 import Data.List (genericReplicate)
 import Data.Proxy
-import Data.Type.Equality (testEquality, (:~:)(..))
+import Data.Type.Equality ((:~:)(..))
 import Text.Parse.Units (parseUnit, universalSymbolTable, UnitExp(..))
 
 import Data.UnitsOfMeasure.Internal
@@ -48,7 +48,7 @@ instance (KnownUnit (Unpack u), u ~ Pack (Unpack u), Read a) => Read (Quantity a
 readWithUnit :: forall proxy a u . (Read a, KnownUnit u) => proxy u -> String -> Either String (Quantity a (Pack u))
 readWithUnit _ s = do
   SomeQuantity (q :: Quantity a _) v <- readQuantity s
-  case testEquality (unitSing :: SUnit u) v of
+  case testEquivalentSUnit (unitSing :: SUnit u) v of
     Just Refl -> Right q
     Nothing   -> Left ("wrong units: got " ++ show (forgetSUnit v))
 

--- a/uom-plugin/tests/Tests.hs
+++ b/uom-plugin/tests/Tests.hs
@@ -177,6 +177,11 @@ tests = testGroup "uom-plugin"
     , testCase "1.2 m/s" $ read (show [u| 1.2 m/s |]) @?= [u| 1.2 m/s |]
     , testCase "0"       $ read (show [u| 1       |]) @?= [u| 1       |]
     ]
+  , testGroup "read normalisation"
+    [ testCase "1 m/m"       $ read "[u| 1 m/m |]"       @?= [u| 1 |]
+    , testCase "-0.3 m s^-1" $ read "[u| -0.3 m s^-1 |]" @?= [u| -0.3 m/s |]
+    , testCase "42 s m s"    $ read "[u| 42 s m s |]"    @?= [u| 42 m s^2 |]
+    ]
   ]
 
 

--- a/uom-plugin/tests/Tests.hs
+++ b/uom-plugin/tests/Tests.hs
@@ -172,6 +172,11 @@ tests = testGroup "uom-plugin"
     , testCase "a ~ b  =>  a ~ kg"    $ given2 undefined `throws` given2_errors
     , testCase "a^2 ~ b^3  =>  a ~ s" $ given3 undefined `throws` given3_errors
     ]
+  , testGroup "read . show"
+    [ testCase "3 m"     $ read (show [u| 3 m     |]) @?= [u| 3 m     |]
+    , testCase "1.2 m/s" $ read (show [u| 1.2 m/s |]) @?= [u| 1.2 m/s |]
+    , testCase "0"       $ read (show [u| 1       |]) @?= [u| 1       |]
+    ]
   ]
 
 

--- a/uom-plugin/uom-plugin.cabal
+++ b/uom-plugin/uom-plugin.cabal
@@ -30,6 +30,7 @@ library
                        Data.UnitsOfMeasure.Defs,
                        Data.UnitsOfMeasure.Internal,
                        Data.UnitsOfMeasure.Plugin,
+                       Data.UnitsOfMeasure.Read,
                        Data.UnitsOfMeasure.Show,
                        Data.UnitsOfMeasure.Singleton,
                        Data.UnitsOfMeasure.Tutorial


### PR DESCRIPTION
Fixes #7. This is a slightly hackish implementation and is a bit under-tested, but it's a start. The actual API exported by `Data.UnitsOfMeasure.Read` could do with some thought, and the relationship between singleton units and `KnownUnit` is a bit unsatisfying.
