### PR TITLE
Raise upper bound on ghc-tcplugins-extra to 0.2

### DIFF
--- a/uom-plugin/uom-plugin.cabal
+++ b/uom-plugin/uom-plugin.cabal
@@ -45,7 +45,7 @@ library
   build-depends:       base >=4.7 && <5,
                        deepseq >=1.3 && <1.5,
                        ghc >= 7.9 && <7.12,
-                       ghc-tcplugins-extra >=0.1 && <0.2,
+                       ghc-tcplugins-extra >=0.1 && <0.3,
                        template-haskell >=2.9 && <2.12,
                        containers >=0.5 && <0.6,
                        units-parser >=0.1 && <0.2


### PR DESCRIPTION
Everything builds and the tests run without issue. The changes in 0.2 just remove some functions not used in uom-plugin.
