### PR TITLE
Ignore .stack-work.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .cabal-sandbox
 cabal.sandbox.config
 dist/
+.stack-work


### PR DESCRIPTION
While adding hlint as a test suite, I noticed that `.stack-work` is not ignored. This pull request is just for that change.

```
$ git status
On branch ignore/stack-work
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   uom-plugin/uom-plugin.cabal

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	uom-plugin/.stack-work/
	uom-plugin/hlint/
```