### PR TITLE
Add GHC -fno-warn-* options.

### DIFF
--- a/uom-plugin-examples/Examples.hs
+++ b/uom-plugin-examples/Examples.hs
@@ -8,8 +8,11 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fplugin Data.UnitsOfMeasure.Plugin #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 import Data.UnitsOfMeasure
-import Data.UnitsOfMeasure.Convert
 import Data.UnitsOfMeasure.Show
 
 import Data.List


### PR DESCRIPTION
When loading the examples into ghci there are a lot of warnings. Rather than clutter the source with type signatures and other minor changes, I've opted to turn off those warnings.