### PR TITLE
fix compilation error on GHC-8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-8.8.3"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.8.3], sources: [hvr-ghc]}}
     - compiler: "ghc-8.6.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.2], sources: [hvr-ghc]}}

--- a/uom-plugin-examples/package.yaml
+++ b/uom-plugin-examples/package.yaml
@@ -14,6 +14,7 @@ tested-with: >+
   GHC == 8.4.4,
   GHC == 8.6.1,
   GHC == 8.6.2
+  GHC == 8.8.3
 extra-source-files:
 - package.yaml
 ghc-options:

--- a/uom-plugin-examples/uom-plugin-examples.cabal
+++ b/uom-plugin-examples/uom-plugin-examples.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 34b490ef7ac228da720237d8afa34e504008281930d0ac23a967b96620344a3e
+-- hash: 366e5263e597a5895113c7eb0b13b451a9757bb96b9277747d9c1f246216cf12
 
 name:           uom-plugin-examples
 version:        0.1.0.0
@@ -13,7 +13,7 @@ description:    This package provides examples of the use of uom-plugin
 author:         Adam Gundry
 maintainer:     adam@well-typed.com
 license:        PublicDomain
-tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.1, GHC == 8.6.2
+tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.1, GHC == 8.6.2 GHC == 8.8.3
 
 build-type:     Simple
 extra-source-files:

--- a/uom-plugin/package.yaml
+++ b/uom-plugin/package.yaml
@@ -32,7 +32,7 @@ library:
   dependencies:
   - base >=4.7 && <5
   - deepseq >=1.3 && <1.5
-  - ghc >= 8.0.1 && <8.7
+  - ghc >= 8.0.1 && <8.9
   - ghc-tcplugins-extra >=0.1
   - template-haskell >=2.9
   - containers >=0.5

--- a/uom-plugin/package.yaml
+++ b/uom-plugin/package.yaml
@@ -22,6 +22,7 @@ tested-with: >+
   GHC == 8.4.4,
   GHC == 8.6.1,
   GHC == 8.6.2
+  GHC == 8.8.3
 extra-source-files:
 - package.yaml
 - changelog

--- a/uom-plugin/src/Data/UnitsOfMeasure/Internal.hs
+++ b/uom-plugin/src/Data/UnitsOfMeasure/Internal.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/uom-plugin/src/Data/UnitsOfMeasure/Singleton.hs
+++ b/uom-plugin/src/Data/UnitsOfMeasure/Singleton.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RoleAnnotations #-}

--- a/uom-plugin/src/GhcApi/Shim.hs
+++ b/uom-plugin/src/GhcApi/Shim.hs
@@ -54,8 +54,8 @@ evDFunApp' = EvDFunApp
 #if __GLASGOW_HASKELL__ >= 806
 evCast' :: EvTerm -> TcCoercion -> EvTerm
 evCast' (EvExpr e)  = evCast e
-evCast' (EvTypeable _ _) = fail "Can't evCast (EvTypeable _ _)"
-evCast' (EvFun _ _ _ _) = fail "Can't evCast (EvFun _ _ _ _)"
+evCast' (EvTypeable _ _) = error "Can't evCast (EvTypeable _ _)"
+evCast' (EvFun _ _ _ _) = error "Can't evCast (EvFun _ _ _ _)"
 #elif __GLASGOW_HASKELL__ >= 802
 evCast' :: EvTerm -> TcCoercion -> EvTerm
 evCast' = EvCast

--- a/uom-plugin/uom-plugin.cabal
+++ b/uom-plugin/uom-plugin.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 248b364d4b6c67ebcf9c1669b2ae9630a4657499f9a3bbb8db4e7609fad4bd38
+-- hash: 40c0f91254b1e86268620a4c7fdc0955672c07d4ec0e9ea55a71c7271f32b24b
 
 name:           uom-plugin
 version:        0.3.0.0
@@ -61,7 +61,7 @@ library
       base >=4.7 && <5
     , containers >=0.5
     , deepseq >=1.3 && <1.5
-    , ghc >=8.0.1 && <8.7
+    , ghc >=8.0.1 && <8.9
     , ghc-tcplugins-extra >=0.1
     , template-haskell >=2.9
     , units-parser >=0.1

--- a/uom-plugin/uom-plugin.cabal
+++ b/uom-plugin/uom-plugin.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 40c0f91254b1e86268620a4c7fdc0955672c07d4ec0e9ea55a71c7271f32b24b
+-- hash: d00ecdf79aa30556cdcd0baab84b15226088e62eae235f340890697ac65f6633
 
 name:           uom-plugin
 version:        0.3.0.0
@@ -22,7 +22,7 @@ maintainer:     Adam Gundry <adam@well-typed.com>
 copyright:      Copyright (c) 2014-2018, Adam Gundry
 license:        BSD3
 license-file:   LICENSE
-tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.1, GHC == 8.6.2
+tested-with:    GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.1, GHC == 8.6.2 GHC == 8.8.3
 
 build-type:     Simple
 extra-source-files:


### PR DESCRIPTION
MonadFail proposal (MFP) removed `fail` from `Monad` class in GHC-8.8 (base-4.13).