### PR TITLE
Convert pack unpack failure

### DIFF
--- a/uom-plugin/test-suite-units/Tests.hs
+++ b/uom-plugin/test-suite-units/Tests.hs
@@ -77,6 +77,7 @@ import Test.Tasty.HUnit
 import Defs ()
 import ErrorTests
 import Z (z)
+import qualified Z (tests)
 
 -- Some basic examples
 
@@ -327,6 +328,7 @@ tests = testGroup "uom-plugin"
     , testCase "2.4 l/h in m" $ convert [u| 2.4 l/ha |] @?= [u| 2.4e-7 m |]
     , testCase "1 m^4 in l m" $ convert [u| 1 m^4 |] @?= [u| 1000 l m |]
     ]
+  , Z.tests
   , testGroup "errors"
     [ testCase "s/m ~ m/s"            $ mismatch1 `throws` mismatch1_errors
     , testCase "m + s"                $ mismatch2 `throws` mismatch2_errors

--- a/uom-plugin/test-suite-units/Z.hs
+++ b/uom-plugin/test-suite-units/Z.hs
@@ -8,7 +8,7 @@
 {-# OPTIONS_GHC -fplugin Data.UnitsOfMeasure.Plugin #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
-module Z (Alt(..), z, tests) where
+module Z (z, tests) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -28,15 +28,23 @@ import Data.UnitsOfMeasure.Defs ()
 {-# ANN z "HLint: ignore Eta reduce" #-}
 z q = convert q
 
-newtype Alt a = Alt a
+newtype A a = A a
+newtype B a = B a
 
-instance (Convertible u [u| m |], q ~ Quantity Double u) => Show (Alt q) where
-    show (Alt x) = show y
+instance (Convertible u [u| m |], q ~ Quantity Double u) => Show (A q) where
+    show (A x) = show y
+        where
+            y :: Quantity Double [u| m |]
+            y = convert x
+
+instance (q ~ Quantity Double [u| m |]) => Show (B q) where
+    show (B x) = show y
         where
             y :: Quantity Double [u| m |]
             y = convert x
 
 tests :: TestTree
 tests = testGroup "show via convert"
-    [ testCase "1.01km" $ show (Alt [u| 1.01 km |]) @?= "[u| 1010.0 m |]"
+    [ testCase "A 1.01km" $ show (A [u| 1.01 km |]) @?= "[u| 1010.0 m |]"
+    , testCase "B 1010m" $ show (B [u| 1010.0 m |]) @?= "[u| 1010.0 m |]"
     ]

--- a/uom-plugin/test-suite-units/Z.hs
+++ b/uom-plugin/test-suite-units/Z.hs
@@ -1,12 +1,21 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -fplugin Data.UnitsOfMeasure.Plugin #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
-module Z (z) where
+module Z (Alt(..), z, tests) where
 
-import Data.UnitsOfMeasure.Convert (convert)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Data.UnitsOfMeasure (Quantity, u)
+import Data.UnitsOfMeasure.Convert (Convertible, convert)
+import Data.UnitsOfMeasure.Defs ()
 
 
 -- Inferring this type used to lead to unit equations with occur-check
@@ -18,3 +27,16 @@ import Data.UnitsOfMeasure.Convert (convert)
 --   -> Quantity a v
 {-# ANN z "HLint: ignore Eta reduce" #-}
 z q = convert q
+
+newtype Alt a = Alt a
+
+instance (Convertible u [u| m |], q ~ Quantity Double u) => Show (Alt q) where
+    show (Alt x) = show y
+        where
+            y :: Quantity Double [u| m |]
+            y = convert x
+
+tests :: TestTree
+tests = testGroup "show via convert"
+    [ testCase "1.01km" $ show (Alt [u| 1.01 km |]) @?= "[u| 1010.0 m |]"
+    ]


### PR DESCRIPTION
Reproduction of the failure:

    Couldn't match type: Data.UnitsOfMeasure.Internal.Pack (Data.UnitsOfMeasure.Internal.Unpack (Base "m")) with: Base "m"